### PR TITLE
Adds seed data for all models except scores, adds Faker::Coffee

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rails-controller-testing'
   gem 'factory_girl_rails'
-  gem 'faker'
+  gem 'faker', git: 'git://github.com/stympy/faker.git', branch: 'master'
   gem 'hirb'
   gem 'shoulda-matchers', '~> 3.1', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/stympy/faker.git
+  revision: 101609556b20933446e706dd0e5e93ffde8dda9d
+  branch: master
+  specs:
+    faker (1.8.0)
+      i18n (~> 0.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -59,8 +67,6 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
-    faker (1.7.2)
-      i18n (~> 0.5)
     ffi (1.9.17)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -175,7 +181,7 @@ DEPENDENCIES
   devise
   devise_token_auth
   factory_girl_rails
-  faker
+  faker!
   hirb
   listen (~> 3.0.5)
   omniauth

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,73 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+if Rails.env.development?
+  # coffees
+  Array.new(50) do
+    Coffee.create!(name: Faker::Coffee.blend_name,
+                   origin: Faker::Coffee.origin,
+                   producer: Faker::Name.name)
+  end if Coffee.count.zero?
+
+  # roasters
+  Array.new(10) do
+    Roaster.create!(name: Faker::Hipster.words(1)[0].capitalize + ' Roastery',
+                    location: Faker::Address.city,
+                    website: Faker::Internet.url)
+  end if Roaster.count.zero?
+
+  # users
+  users = Array.new(10) do
+    User.create!(name: Faker::Name.name,
+                 username: Faker::Internet.user_name,
+                 email: Faker::Internet.email,
+                 password: 'password',
+                 password_confirmation: 'password')
+  end if User.count.zero?
+
+  # only make past cuppings if no cuppings exist
+  if Cupping.count.zero?
+    past_cuppings = users.map.with_index do |user, idx|
+      # other half of users are past cupping hosts
+      user.hosted_cuppings.create!(location: Faker::Address.street_address,
+                                   cup_date: DateTime.now - idx,
+                                   cups_per_sample: 5) if idx.even?
+    end
+  else
+    past_cuppings = []
+  end
+
+  # always make new future cuppings
+  future_cuppings = users.map.with_index do |user, idx|
+    user.hosted_cuppings.create!(location: Faker::Address.street_address,
+                                 cup_date: DateTime.now + idx,
+                                 cups_per_sample: 3) if idx.odd?
+  end
+
+  # all cuppings
+  cuppings = future_cuppings + past_cuppings
+
+  # to get rid of nil values
+  cuppings.select! { |cupping| !cupping.nil? }
+
+  # add cupped coffees to cuppings
+  cuppings.each do |cupping|
+    3.times do
+      cupping.cupped_coffees.create!(roast_date: cupping.cup_date - 1,
+                                     coffee_alias: "#{cupping.id}-#{rand(999)}",
+                                     coffee_id: Coffee.all.sample.id,
+                                     roaster_id: Roaster.all.sample.id)
+    end
+  end
+
+  # add invites to cuppings
+  cuppings.each do |cupping|
+    3.times do
+      cupping.invites.create!(grader_id:
+        if cupping.invites.empty?
+          User.where('id != ?', cupping.host_id).sample.id
+        else
+          User.where('id != ? AND id NOT IN (?)', cupping.host_id,
+                     cupping.invites.pluck(:grader_id))
+                       .sample.id
+        end)
+    end
+  end
+end


### PR DESCRIPTION
Updates the Faker gem to use current 'master' branch version, which allows Faker::Coffee.
Can be declared as usual `gem 'faker'` when next official gem version (1.8) is released.
Be sure to `bundle install` and `be rake db:reset`!
Holding off on adding scores to seed data for now...let's revisit once we've reasoned a little more about the controllers/requests/etc.