### PR TITLE
Adds 'open' attribute to cupping model w/specs

### DIFF
--- a/db/migrate/20170415192306_add_open_to_cuppings.rb
+++ b/db/migrate/20170415192306_add_open_to_cuppings.rb
@@ -1,0 +1,5 @@
+class AddOpenToCuppings < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cuppings, :open, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170401214101) do
+ActiveRecord::Schema.define(version: 20170415192306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,10 +40,11 @@ ActiveRecord::Schema.define(version: 20170401214101) do
   create_table "cuppings", force: :cascade do |t|
     t.string   "location"
     t.datetime "cup_date"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.integer  "host_id"
     t.integer  "cups_per_sample"
+    t.boolean  "open",            default: true
     t.index ["host_id"], name: "index_cuppings_on_host_id", using: :btree
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :user do
     name { Faker::Name.name }
-    username { Faker::Internet.user_name }
-    email { Faker::Internet.email }
+    username { Faker::Internet.unique.user_name }
+    email { Faker::Internet.unique.email }
     password 'password'
     password_confirmation 'password'
   end

--- a/spec/models/cupping_spec.rb
+++ b/spec/models/cupping_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Cupping, type: :model do
     it { should respond_to(:cup_date) }
     it { should respond_to(:cups_per_sample) }
     it { should respond_to(:host_id) }
+    it { should respond_to(:open) }
+    it 'open attribute should default to true' do
+      expect(cupping.open).to be true
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
add an 'open' boolean attribute to cupping model to facilitate restrictions on adding scores/cuppedcoffees/invites to a past/finished-cupping